### PR TITLE
comment_model_route_controller_create

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,7 @@
 class MessagesController < ApplicationController
   def index
   end
+  
+  def create
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,6 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
          has_many :messages
-         has_many :group_users
+         has_many :group_users         
          has_many :groups, through: :group_users
 end

--- a/db/migrate/20190829113954_create_messages.rb
+++ b/db/migrate/20190829113954_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190829021746) do
+ActiveRecord::Schema.define(version: 20190829113954) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 20190829021746) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 20190829021746) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
メッセージモデルを作成
モデルにカラムを追加
各モデルにアソシエーションを追加
メーセージのimageにバリデーションをかけた
バリデーションの内容はimageを指定していなくても登録可能
ルーティングの設定
コントローラにindexとcreateを追加