### PR TITLE
message_group_display

### DIFF
--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -85,31 +85,15 @@ a {
         }
       }
     }
-    &__lower {
+    .messages{
       overflow: scroll;
+      height:calc(100vh - 200px);
+    }
+    &__lower {
       height:calc(100vh - 200px);
       background-color: #fafafa;
       &__uppersize {
         padding:46px 0 0 40px;
-      }
-      &__userdays {
-        display: flex;
-          &__username {
-          padding:0 10px 10px 40px;
-          font-size: 16px;
-          font-weight:bold; 
-          color: #434a54;
-        }
-        &__days {
-          display: flex;
-          font-size: 12px;
-          color: #999999;
-        }
-      }
-      &__text {
-        padding:0 0 40px 40px;
-        font-size: 14px;
-        color: #434a54;
       }
       &__userdays {
         display: flex;
@@ -143,30 +127,33 @@ a {
           width:calc(100vw - 300px);
           height:100%;
           align-items:center;
-
           .new_message{
             display: flex;
             width: 100%;
           }
-
-          &__message{
-            position: relative;
+          .formbox{
+            display: flex;
             width: 100%;
             height: 50px;
-            font-size: 16px;
             margin:0 0 0 40px;
-            padding:0 10px 0 10px;
-          }
-          .form{
-            &__mask{
-              position: absolute;
-              bottom:35px;
-              right:165px;
-            &__image{
-                .icon{
-                }
-                .hidden{
-                  display: none;
+            &__message{
+              position: relative;
+              height: 50px;
+              font-size: 16px;
+              padding:0 10px 0 10px;
+              width: 100%;
+            }
+            .form{
+              &__mask{
+                position: absolute;
+                right:165px;
+                margin:15px 0 0 0;
+                &__image{
+                  .icon{
+                  }
+                  .hidden{
+                    display: none;
+                  }
                 }
               }
             }

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,13 @@
+.message
+  .content-rightside__lower
+    .content-rightside__lower__uppersize
+    .content-rightside__lower__userdays
+      .content-rightside__lower__userdays__username
+        = message.user.name
+      .content-rightside__lower__userdays__days
+        = message.created_at.strftime("%Y/%m/%d %H:%M")
+    .content-rightside__lower__text
+      - if message.content.present?
+        %p.lower-message__content
+          = message.content
+      = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -13,74 +13,16 @@
       .content-rightside__upper__right
         .content-rightside__upper__editbutton
           = link_to 'edit', '/groups/1/edit', style: "color:#7ee2e2"
-    .content-rightside__lower
-      .content-rightside__lower__uppersize
-      .content-rightside__lower__userdays
-        .content-rightside__lower__userdays__username
-          ユーザーネーム
-        .content-rightside__lower__userdays__days
-          2019/08/22(Thu)09:15:48
-      .content-rightside__lower__text
-        テキスト
-      .content-rightside__lower__userdays
-        .content-rightside__lower__userdays__username
-          ユーザーネーム
-        .content-rightside__lower__userdays__days
-          2019/08/22(Thu)09:15:48
-      .content-rightside__lower__text
-        テキスト
-      .content-rightside__lower__userdays
-        .content-rightside__lower__userdays__username
-          ユーザーネーム
-        .content-rightside__lower__userdays__days
-          2019/08/22(Thu)09:15:48
-      .content-rightside__lower__text
-        テキスト
-      .content-rightside__lower__userdays
-        .content-rightside__lower__userdays__username
-          ユーザーネーム
-        .content-rightside__lower__userdays__days
-          2019/08/22(Thu)09:15:48
-      .content-rightside__lower__text
-        テキスト
-      .content-rightside__lower__userdays
-        .content-rightside__lower__userdays__username
-          ユーザーネーム
-        .content-rightside__lower__userdays__days
-          2019/08/22(Thu)09:15:48
-      .content-rightside__lower__text
-        テキスト
-      .content-rightside__lower__userdays
-        .content-rightside__lower__userdays__username
-          ユーザーネーム
-        .content-rightside__lower__userdays__days
-          2019/08/22(Thu)09:15:48
-      .content-rightside__lower__text
-        テキスト
-      .content-rightside__lower__userdays
-        .content-rightside__lower__userdays__username
-          ユーザーネーム
-        .content-rightside__lower__userdays__days
-          2019/08/22(Thu)09:15:48
-      .content-rightside__lower__text
-        テキスト
+    .messages
+      = render @messages
     .content-rightside__lower__bottom
       .content-rightside__lower__bottom__box
         .form
           = form_for [@group, @message] do |f|
-            = f.text_field :content, class: 'form__message', placeholder: 'type a message'
-            .form__mask
-              = f.label :image, class: 'form__mask__image' do
-                = fa_icon 'picture-o', class: 'icon'
-                = f.file_field :image, class: 'hidden'
+            .formbox
+              = f.text_field :content, class: 'formbox__message', placeholder: 'type a message'
+              .form__mask
+                = f.label :image, class: 'form__mask__image' do
+                  = fa_icon 'picture-o', class: 'icon'
+                  = f.file_field :image, class: 'hidden'
             = f.submit 'Send', class: 'form__submit'
-
-
-
-    -#     %form{class: "form"}
-    -#       %input.form__message{placeholder: "type a message"}
-    -#       .form__mask
-    -#         %label.form__mask__image
-    -#           = fa_icon 'picture-o', class: 'icon'
-    -#           %input.hidden{type: 'file'}
-    -#       %input.form__submit{type: 'submit', value: 'Send'}

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,8 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.action_view.field_error_proc = Proc.new do |html_tag, instance|
+      %Q(#{html_tag}).html_safe
+    end
   end
 end


### PR DESCRIPTION
グループにメッセージを表示する
form_forでグループを表示するためにコードをコピーするとcssが崩れたのでimage部分は直した
<div class="field_with_errors">についてはform_forが勝手にcssを壊す場合があるのでconfig.actionviewにコードをコピーをして回避するようにした
部分テンプレートをして際にright_lowerのスクロールバーがおかしくなったので、comments要素を追加してそこにスクロールバーとcalc(100VW - 200px)のコードを記入してスクロールバーをつけた。