### PR TITLE
view_many_little_parts_changed

### DIFF
--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -66,10 +66,12 @@ a {
       &__left {
         &__groupname {
           padding:35px 0 0 40px;
+          color: #333333;
           font-size: 20px;
         }
         &__username {
           padding:15px 0 0 40px;
+          color: #999999;
           font-size: 12px;
         }
       }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,8 +8,9 @@
       .content-rightside__upper__left
         .content-rightside__upper__left__groupname
           グループ名
-        .content-rightside__upper__left__username
-          Member:ユーザーネーム
+          -# = group.name
+          = current_user.name
+
       .content-rightside__upper__right
         .content-rightside__upper__editbutton
           = link_to 'edit', '/groups/1/edit', style: "color:#7ee2e2"

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -17,4 +17,4 @@
           .group__name
             = group.name
           .group__message
-            メッセージはまだありません。
+            = group.show_last_message


### PR DESCRIPTION
viewのrightside_lowerにユーザー名とメッセージの実装を行なった
right_side_upperにはグループ名と、グループに属するメンバーを表示したかっらができなかったので保留にした。